### PR TITLE
Glob pattern fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,9 @@ You may use any name for your fragments, just omit double quotes (`"`) and symbo
 
 #### More on Fragments
 
-A fragment may be partitioned within the file.When rendered, the partitions of a fragment are joined
-together and interlaid with a special interlaying text (see [Configuration](#configuration)).
+A fragment may consist of one or several pieces declared in a single file. When rendered, the pieces
+which belong to a single fragment are joined together. One may also specify the text inserted in
+each joint point (see [Configuration](#configuration) for the corresponding parameter).
 
 Here is an example of how a re-occurring fragment is rendered.
 
@@ -116,8 +117,9 @@ public final class String
 }
 ```
 
-Note the usage of spaces in the fragment names. Thanks to putting fragment names into quotes, normal
-natual language can be used instead of `CamelCase`, `snake_case`, or `kebab-case`.
+As the name of each fragment is put into quotes, space symbols may be used. So one may use the
+natural language (e.g. "My favorite fragment here!") instead of `CamelCase`, `snake_case`, or
+`kebab-case` (e.g. "my-favourite-fragment-here-exclamation-mark").
 
 **Result:**
 
@@ -184,7 +186,7 @@ In order for the command to work, you need to specify at least two configuration
  - `code_root` — the directory where all the embedded code resides;
  - `documentation_root` — the directory where all the docs which need embedding reside.
 
-Those parameters should be specified via the Jekyll `_condig.yml` file.
+Those parameters should be specified via the Jekyll `_config.yml` file.
 
 For example:
 ```yaml
@@ -213,9 +215,10 @@ Other command configuration parameters include:
 
 ## Development
 
-This software is written in Ruby as it's a plug-in for Ruby-based [Jekyll](https://jekyllrb.com/).
-While Ruby may not be familiar to you, this plug-in consists of the trivial string and file
-manipulations which should be easy to understand.
+This software is written in Ruby as a plug-in for [Jekyll](https://jekyllrb.com/).
+
+The minimal required version of Ruby is `2.5` (constrained by Jekyll). However, it is recommended to
+use Ruby `2.7` or above, as it has security fixes for issues in `2.5`.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ bundle exec jekyll embedCodeSamples
 
 ### In Markdown
 
+#### Named fragments
+
 To add a new code sample, add the following construct to the Markdown file:
 
 <pre>
@@ -35,20 +37,38 @@ To add a new code sample, add the following construct to the Markdown file:
 ```   
 </pre>
 
-This is an `<?embed-code?>` tag followed by a code fence (with the language you need). The code
-fence may be empty, or not empty, the command will overwrite it automatically. 
+This is an `<?embed-code?>` tag followed by a code fence (with the language you need). The content
+of the code fence does not matter — the command will overwrite it automatically.
 
-#### Supported Attributes
+The `file` attribute specifies the path to the code file relative to the code root, specified in
+the configuration. The `fragment` attribute specifies the name of the code fragment to embed. Omit
+this attribute to embed the whole file.
 
- * `file` — a path to the code file relative to the code root, specified in the configuration.
- * `fragment` — a name of the fragment in the specified file. Omit documentation fragment if you
-want to embed the whole file.
+#### Pattern fragments
+
+Alternatively, the `<?embed-code?>` tag may have the following form:
+<pre>
+&lt;?embed-code file=&quot;java/lang/String.java&quot;
+             start=&quot;*class Hello*&quot;
+             end=&quot;}*&quot;?&gt;
+```java
+```   
+</pre>
+
+The difference is that here fragment is specified by a pair of glob-style patterns. The patterns
+match the first and the last lines of the desired code fragment. Any of the patterns may be skipped.
+In such case, the fragment starts at the beginning or ends at the end of the code file.
+
+The pattern syntax supports basic glob constructs:
+ - `?` — one arbitrary symbol;
+ - `*` — zero, one, or many arbitrary symbols;
+ - `[set]` — one symbol from the given set (equivalent to `[set]` in regular expressions).
 
 ### In Code
 
 The whole file can be embedded without any additional effort.
 
-If you want to embed only a relevant portion of the file, mark it up into fragments like this:
+You can mark up the code file to select named fragments like this:
 
 ```java
 public final class String
@@ -71,7 +91,7 @@ public final class String
 }
 ```
 
-The fragments mark-up won't be rendered into Markdown.
+The `#docfragment` and `#enddocfragment` tags won't be copied into the resulting code fragment.
 
 #### Fragment Naming
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ of the code fence does not matter — the command will overwrite it automaticall
 
 The `file` attribute specifies the path to the code file relative to the code root, specified in
 the configuration. The `fragment` attribute specifies the name of the code fragment to embed. Omit
-this attribute to embed the whole file.
+this attribute to embed the whole file or to use glob patterns.
 
 #### Pattern fragments
 
@@ -57,7 +57,7 @@ Alternatively, the `<?embed-code?>` tag may have the following form:
 
 The difference is that here fragment is specified by a pair of glob-style patterns. The patterns
 match the first and the last lines of the desired code fragment. Any of the patterns may be skipped.
-In such case, the fragment starts at the beginning or ends at the end of the code file.
+In such a case, the fragment starts at the beginning or ends at the end of the code file.
 
 The pattern syntax supports basic glob constructs:
  - `?` — one arbitrary symbol;

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ Alternatively, the `<?embed-code?>` tag may have the following form:
 ```   
 </pre>
 
-The difference is that here fragment is specified by a pair of glob-style patterns. The patterns
-match the first and the last lines of the desired code fragment. Any of the patterns may be skipped.
+In this case, the fragment is specified by a pair of glob-style patterns. The patterns match 
+the first and the last lines of the desired code fragment. Any of the patterns may be skipped.
 In such a case, the fragment starts at the beginning or ends at the end of the code file.
 
 The pattern syntax supports basic glob constructs:

--- a/lib/commands/embedding_instruction.rb
+++ b/lib/commands/embedding_instruction.rb
@@ -103,7 +103,7 @@ module Jekyll::Commands
         end_position = nil
       end
       required_lines = lines[start_position..end_position]
-      indentation = find_minimal_indentation(required_lines)
+      indentation = max_common_indentation(required_lines)
       required_lines.map { |line| line[indentation..-1] }
     end
   end

--- a/lib/commands/embedding_instruction.rb
+++ b/lib/commands/embedding_instruction.rb
@@ -20,6 +20,7 @@ require 'nokogiri'
 require 'jekyll'
 
 require_relative 'fragmentation'
+require_relative 'indent'
 
 module Jekyll::Commands
 
@@ -96,7 +97,9 @@ module Jekyll::Commands
       else
         end_position = nil
       end
-      lines[start_position..end_position]
+      required_lines = lines[start_position..end_position]
+      indentation = find_minimal_indentation(required_lines)
+      required_lines.map { |line| line[indentation..-1] }
     end
   end
 end

--- a/lib/commands/embedding_instruction.rb
+++ b/lib/commands/embedding_instruction.rb
@@ -57,8 +57,8 @@ module Jekyll::Commands
     # @param [Configuration] configuration tool configuration
     def self.from_xml(line, configuration)
       begin
-      document = Nokogiri::XML(line)
-      instruction = document.at_xpath("//processing-instruction('#{TAG_NAME}')")
+        document = Nokogiri::XML(line)
+        instruction = document.at_xpath("//processing-instruction('#{TAG_NAME}')")
       rescue StandardError => e
         puts e
         return nil

--- a/lib/commands/embedding_instruction.rb
+++ b/lib/commands/embedding_instruction.rb
@@ -69,7 +69,6 @@ module Jekyll::Commands
       tag = instruction.to_element
       fields = tag.attributes.map { |name, value| [name, value.to_s] }.to_h
       EmbeddingInstruction.new(fields, configuration)
-
     end
 
     # Reads the specified fragment from the code.

--- a/lib/commands/fragmentation.rb
+++ b/lib/commands/fragmentation.rb
@@ -19,6 +19,7 @@
 require 'fileutils'
 require 'digest/sha1'
 require_relative 'configuration'
+require_relative 'indent'
 
 module Jekyll::Commands
 
@@ -342,19 +343,6 @@ module Jekyll::Commands
     def fragment_hash
       # Allows to use any characters in a fragment name
       (Digest::SHA1.hexdigest @fragment_name)[0..7]
-    end
-
-    def find_minimal_indentation(lines)
-      min_indentation = Float::INFINITY
-      lines.each do |line|
-        unless line.strip.empty?
-          spaces = line[/\A */].size
-          if spaces < min_indentation
-            min_indentation = spaces
-          end
-        end
-      end
-      min_indentation
     end
   end
 end

--- a/lib/commands/fragmentation.rb
+++ b/lib/commands/fragmentation.rb
@@ -333,7 +333,7 @@ module Jekyll::Commands
 
     def write_lines(content, open_mode)
       File.open(absolute_path, open_mode) do |f|
-        indentation = find_minimal_indentation(content)
+        indentation = max_common_indentation(content)
         content.each do |line|
           f.puts(line[indentation..-1])
         end

--- a/lib/commands/indent.rb
+++ b/lib/commands/indent.rb
@@ -1,0 +1,30 @@
+# Copyright 2020, TeamDev. All rights reserved.
+#
+# Redistribution and use in source and/or binary forms, with or without
+# modification, must retain the above copyright notice and the following
+# disclaimer.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+def find_minimal_indentation(lines)
+  min_indentation = Float::INFINITY
+  lines.each do |line|
+    unless line.strip.empty?
+      spaces = line[/\A */].size
+      if spaces < min_indentation
+        min_indentation = spaces
+      end
+    end
+  end
+  min_indentation
+end

--- a/lib/commands/indent.rb
+++ b/lib/commands/indent.rb
@@ -16,7 +16,11 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-def find_minimal_indentation(lines)
+# Finds the maximal common indentation of the given lines.
+#
+# @param lines an array of lines which may or may not have leading whitespaces
+# @return the number of leading whitespaces in all the lines except for the empty ones
+def max_common_indentation(lines)
   min_indentation = Float::INFINITY
   lines.each do |line|
     unless line.strip.empty?

--- a/test/commands/embedding_instruction_test.rb
+++ b/test/commands/embedding_instruction_test.rb
@@ -39,4 +39,30 @@ class EmbeddingInstructionTest < Test::Unit::TestCase
     assert_equal(28, lines.size)
     assert_equal("public class Hello {\n", lines[22])
   end
+
+  def test_fragment_and_start
+    xml = build_instruction 'org/example/Hello.java', 'fr1', 'public void hello()'
+    assert_raise ArgumentError do
+      Jekyll::Commands::EmbeddingInstruction.from_xml(xml, config_with_prepared_fragments)
+    end
+  end
+
+  def test_fragment_and_end
+    xml = build_instruction 'org/example/Hello.java', 'fr2', nil, '}'
+    assert_raise ArgumentError do
+      Jekyll::Commands::EmbeddingInstruction.from_xml(xml, config_with_prepared_fragments)
+    end
+  end
+
+  def test_extract_by_glob
+    xml = build_instruction 'org/example/Hello.java', nil, 'public class*', '*System.out*'
+    puts xml
+    configuration = config_with_prepared_fragments
+    instruction = Jekyll::Commands::EmbeddingInstruction.from_xml(xml, configuration)
+    lines = instruction.content
+    assert_not_nil(lines)
+    assert_equal(4, lines.size)
+    assert_equal("public class Hello {\n", lines.first)
+    assert_equal("        System.out.println(\"Hello world\");\n", lines.last)
+  end
 end

--- a/test/commands/embedding_instruction_test.rb
+++ b/test/commands/embedding_instruction_test.rb
@@ -77,4 +77,35 @@ class EmbeddingInstructionTest < Test::Unit::TestCase
     assert_match(/\s{4}.+/, lines[1])
     assert_equal("}\n", lines.last)
   end
+
+  def test_start_without_end
+    xml = build_instruction 'org/example/Hello.java', nil, '*class*'
+    configuration = config_with_prepared_fragments
+    instruction = Jekyll::Commands::EmbeddingInstruction.from_xml(xml, configuration)
+    lines = instruction.content
+    assert_not_nil(lines)
+    assert_equal(6, lines.size)
+    assert_equal("}\n", lines.last)
+  end
+
+  def test_end_without_start
+    xml = build_instruction 'org/example/Hello.java', nil, nil, 'package*'
+    configuration = config_with_prepared_fragments
+    instruction = Jekyll::Commands::EmbeddingInstruction.from_xml(xml, configuration)
+    lines = instruction.content
+    assert_not_nil(lines)
+    assert_equal(21, lines.size)
+    assert_equal("/*\n", lines.first)
+    assert_equal("package org.example;\n", lines.last)
+  end
+
+  def test_one_line
+    xml = build_instruction 'org/example/Hello.java', nil, '*main*', '*main*'
+    configuration = config_with_prepared_fragments
+    instruction = Jekyll::Commands::EmbeddingInstruction.from_xml(xml, configuration)
+    lines = instruction.content
+    assert_not_nil(lines)
+    assert_equal(1, lines.size)
+    assert_equal("public static void main(String[] args) {\n", lines.first)
+  end
 end

--- a/test/commands/embedding_instruction_test.rb
+++ b/test/commands/embedding_instruction_test.rb
@@ -56,7 +56,6 @@ class EmbeddingInstructionTest < Test::Unit::TestCase
 
   def test_extract_by_glob
     xml = build_instruction 'org/example/Hello.java', nil, 'public class*', '*System.out*'
-    puts xml
     configuration = config_with_prepared_fragments
     instruction = Jekyll::Commands::EmbeddingInstruction.from_xml(xml, configuration)
     lines = instruction.content
@@ -64,5 +63,18 @@ class EmbeddingInstructionTest < Test::Unit::TestCase
     assert_equal(4, lines.size)
     assert_equal("public class Hello {\n", lines.first)
     assert_equal("        System.out.println(\"Hello world\");\n", lines.last)
+  end
+
+  def test_min_indentation
+    xml = build_instruction 'org/example/Hello.java', nil, '*public static void main*', '*}*'
+    configuration = config_with_prepared_fragments
+    instruction = Jekyll::Commands::EmbeddingInstruction.from_xml(xml, configuration)
+    lines = instruction.content
+    assert_not_nil(lines)
+    assert_equal(3, lines.size)
+    assert_not_equal(' ', lines.first[0])
+    assert_match(/^public.+/, lines.first)
+    assert_match(/\s{4}.+/, lines[1])
+    assert_equal("}\n", lines.last)
   end
 end

--- a/test/commands/given/test_env.rb
+++ b/test/commands/given/test_env.rb
@@ -17,7 +17,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 def config_with_prepared_fragments
-  config(prepared_fragments = true)
+  config(true)
 end
 
 def config(prepared_fragments = false, code_includes = nil)
@@ -41,13 +41,25 @@ def prepare_docs(source)
   FileUtils.copy_entry source, config.documentation_root
 end
 
-def build_instruction(file_name, fragment = nil)
-  fragment_attr = fragment ? "fragment=\"#{fragment}\"" : ''
-  "<?embed-code file=\"#{file_name}\" #{fragment_attr}?>"
+def build_instruction(file_name, fragment = nil, start_glob = nil, end_glob = nil)
+  fragment_attr = xml_attribute 'fragment', fragment
+  start_attr = xml_attribute 'start', start_glob
+  end_attr = xml_attribute 'end', end_glob
+  "<?embed-code file=\"#{file_name}\" #{fragment_attr} #{start_attr} #{end_attr}?>"
 end
 
 def delete_dir(path)
   if File.exist?(path)
     FileUtils.rm_r path, secure: true
+  end
+end
+
+private
+
+def xml_attribute(name, value)
+  if value.nil?
+    ''
+  else
+    "#{name}=\"#{value}\""
   end
 end


### PR DESCRIPTION
In this PR we allow specifying code fragments using glob patterns:
```
<?embed-code file="path/to/file" start="*void main*" end="????}*"?>
```

The tag allows specifying only `start`, only `end`, or both `start` and `end` patterns. If `end` is skipped, the fragment ends at the end of the file. If `start` is skipped, the fragment starts at the start of the file.


The pattern syntax supports basic glob constructs:
 - `?` — one arbitrary symbol;
 - `*` — zero, one, or many arbitrary symbols;
 - `[set]` — one symbol from the given set (equivalent to `[set]` in regular expressions).