### PR TITLE
Fail on unmatched pattern and allow to skip `*`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+## Development
+
+This software is written in Ruby as a plug-in for [Jekyll](https://jekyllrb.com/).
+
+The minimal required version of Ruby is `2.5` (constrained by Jekyll). However, it is recommended to
+use Ruby `2.7` or above, as it has security fixes for issues in `2.5`.
+
+## Testing
+
+Before running tests, make sure to:
+
+1. Install Ruby. Check installation by running:
+    ```
+    ruby -v
+    ```
+2. Install Bundler:
+    ```
+    gem install bundler
+    ```
+3. Install project dependencies:
+    ```
+    bundle install
+    ```
+
+Now, run tests using the `test/run.rb` script:
+```
+ruby ./test/run.rb
+```
+
+When launched on Travis CI, the script also collects and uploads code coverage data.

--- a/README.md
+++ b/README.md
@@ -24,9 +24,30 @@ the standard `gem` tool. Also, we don't publish `embed-code` into any Gem reposi
 bundle exec jekyll embedCodeSamples
 ```
 
-### In Markdown
+### In the documentation file
 
-#### Named fragments
+Synopsis:
+```
+<?embed-code file="path/to/file" fragment="Fragment Name"?> (I)
+
+OR
+
+<?embed-code file="path/to/file" start="first?line*glob" end="last?line*glob"?> (II)
+```
+
+The instruction must always be followed by a code fence (opening and closing three backticks):
+
+<pre>
+<?embed-code ...?>
+```java
+```
+</pre>
+
+Note that the code fence may specify the syntax in which the code will be highlighted.
+
+This is true even when embedding into HTML.
+
+#### Named fragments (I)
 
 To add a new code sample, add the following construct to the Markdown file:
 
@@ -64,7 +85,7 @@ The pattern syntax supports basic glob constructs:
  - `*` — zero, one, or many arbitrary symbols;
  - `[set]` — one symbol from the given set (equivalent to `[set]` in regular expressions).
 
-### In Code
+### In the code file
 
 The whole file can be embedded without any additional effort.
 
@@ -251,41 +272,3 @@ however, the code fragments are outdated, the command reports an error.
 Under the hood, the command constructs the same code embeddings as does `embedCodeSamples`, but
 instead of changing the doc files, checks if the files on the file system are identical to the ones
 it constructed. If they are not, the process finishes with a non-0 exit code.
-
-## Development
-
-This software is written in Ruby as a plug-in for [Jekyll](https://jekyllrb.com/).
-
-The minimal required version of Ruby is `2.5` (constrained by Jekyll). However, it is recommended to
-use Ruby `2.7` or above, as it has security fixes for issues in `2.5`.
-
-## Testing
-
-Before running tests, make sure to:
-
-1. Install Ruby. Check installation by running:
-    ```
-    ruby -v
-    ```
-2. Install Bundler:
-    ```
-    gem install bundler
-    ```
-3. Install project dependencies:
-    ```
-    bundle install
-    ```
-
-Now, run tests using the `test/run.rb` script:
-```
-ruby ./test/run.rb
-```
-
-When launched on Travis CI, the script also collects and uploads code coverage data.
-
-### IDEA Live Template
-
-```
-// #docfragment "$NAME$"
-// #enddocfragment "$NAME$"
-```

--- a/lib/commands/embedding_instruction.rb
+++ b/lib/commands/embedding_instruction.rb
@@ -112,21 +112,32 @@ module Jekyll::Commands
   class Pattern
 
     def initialize(glob)
+      @source_glob = glob
       pattern = glob
       start_of_line = glob.start_with?('^')
       if !start_of_line && !glob.start_with?('*')
         pattern = '*' + pattern
       end
-
+      if start_of_line
+        pattern = pattern[1..nil]
+      end
       end_of_line = glob.end_with?('$')
       if !end_of_line && !glob.end_with?('*')
         pattern += '*'
       end
+      if end_of_line
+        pattern = pattern[0..pattern.length - 2]
+      end
+
       @pattern = pattern
     end
 
     def match?(line)
-      File.fnmatch?(@pattern, line)
+      File.fnmatch?(@pattern, line.chomp)
+    end
+
+    def to_s
+      "Pattern #{@source_glob}"
     end
   end
 

--- a/lib/commands/embedding_instruction.rb
+++ b/lib/commands/embedding_instruction.rb
@@ -86,24 +86,24 @@ module Jekyll::Commands
     private
 
     def matching_lines(lines)
-      start_position = 0
-      line_count = lines.length
-      if @start
-        until start_position >= line_count || File.fnmatch?(@start, lines[start_position])
-          start_position += 1
-        end
-      end
-      end_position = start_position
-      if @end
-        until end_position >= line_count || File.fnmatch(@end, lines[end_position])
-          end_position += 1
-        end
-      else
-        end_position = nil
-      end
+      start_position = @start ? match_glob(@start, lines, 0) : 0
+      end_position = @end ? match_glob(@end, lines, start_position) : nil
+
       required_lines = lines[start_position..end_position]
       indentation = max_common_indentation(required_lines)
       required_lines.map { |line| line[indentation..-1] }
+    end
+
+    def match_glob(pattern, lines, start_from)
+      line_count = lines.length
+      result_line = start_from
+      until result_line >= line_count
+        line = lines[result_line]
+        return result_line if File.fnmatch?(pattern, line)
+
+        result_line += 1
+      end
+      raise "There is no line matching `#{pattern}`."
     end
   end
 end

--- a/lib/commands/fragmentation.rb
+++ b/lib/commands/fragmentation.rb
@@ -275,7 +275,6 @@ module Jekyll::Commands
           part_text.each do |line|
             text += line[common_indentation..-1]
           end
-          text += configuration.separator + "\n"
         end
         text.freeze
       end
@@ -367,29 +366,15 @@ module Jekyll::Commands
     #
     # Overwrites the file if it exists.
     def write(content)
-      write_lines content, 'w+'
-    end
-
-    def append(content)
-      write_lines content, 'a+'
-    end
-
-    def exists?
-      File.exist? absolute_path
-    end
-
-    private
-
-    def write_lines(content, open_mode)
-      File.open(absolute_path, open_mode) do |file|
-        content.each do |line|
-          file.puts(line)
-        end
+      File.open(absolute_path, 'w+') do |file|
+        file.puts(content)
       end
     rescue StandardError => e
       puts "Error while writing file #{self}: #{e}"
       puts e.backtrace
     end
+
+    private
 
     def fragment_hash
       # Allows to use any characters in a fragment name

--- a/lib/commands/fragmentation.rb
+++ b/lib/commands/fragmentation.rb
@@ -271,7 +271,11 @@ module Jekyll::Commands
         end
 
         text = ''
-        partition_lines.each do |part_text|
+
+        partition_lines.each_with_index do |part_text, index|
+          if index != 0
+            text += configuration.separator + "\n"
+          end
           part_text.each do |line|
             text += line[common_indentation..-1]
           end

--- a/test/commands/embedding_instruction_test.rb
+++ b/test/commands/embedding_instruction_test.rb
@@ -126,4 +126,34 @@ class EmbeddingInstructionTest < Test::Unit::TestCase
       instruction.content
     end
   end
+
+  def test_imply_asterisk
+    xml = build_instruction 'org/example/Hello.java', nil, 'main', 'world'
+    configuration = config_with_prepared_fragments
+    instruction = Jekyll::Commands::EmbeddingInstruction.from_xml(xml, configuration)
+    lines = instruction.content
+    assert_equal(2, lines.size)
+    assert_true(lines.first.start_with?('public static void main'))
+    assert_true(lines.last.start_with?('    System.out.println'))
+  end
+
+  def test_explicit_line_start
+    xml = build_instruction 'plain-text-to-embed.txt', nil, '^foo', '^bar'
+    configuration = config_with_prepared_fragments
+    instruction = Jekyll::Commands::EmbeddingInstruction.from_xml(xml, configuration)
+    lines = instruction.content
+    assert_equal(4, lines.size)
+    assert_equal("foo — this line starts with it\n", lines.first)
+    assert_equal("bar — this line starts with it\n", lines.last)
+  end
+
+  def test_explicit_line_end
+    xml = build_instruction 'plain-text-to-embed.txt', nil, 'foo$', 'bar$'
+    configuration = config_with_prepared_fragments
+    instruction = Jekyll::Commands::EmbeddingInstruction.from_xml(xml, configuration)
+    lines = instruction.content
+    assert_equal(6, lines.size)
+    assert_equal("This line ends with foo\n", lines.first)
+    assert_equal("This line ends with bar\n", lines.last)
+  end
 end

--- a/test/commands/embedding_instruction_test.rb
+++ b/test/commands/embedding_instruction_test.rb
@@ -108,4 +108,22 @@ class EmbeddingInstructionTest < Test::Unit::TestCase
     assert_equal(1, lines.size)
     assert_equal("public static void main(String[] args) {\n", lines.first)
   end
+
+  def test_no_match_start
+    xml = build_instruction 'org/example/Hello.java', nil, 'foo bar', '*main*'
+    configuration = config_with_prepared_fragments
+    instruction = Jekyll::Commands::EmbeddingInstruction.from_xml(xml, configuration)
+    assert_raise do
+      instruction.content
+    end
+  end
+
+  def test_no_match_end
+    xml = build_instruction 'org/example/Hello.java', nil, '*main*', 'foo bar'
+    configuration = config_with_prepared_fragments
+    instruction = Jekyll::Commands::EmbeddingInstruction.from_xml(xml, configuration)
+    assert_raise do
+      instruction.content
+    end
+  end
 end

--- a/test/commands/fragmentation_test.rb
+++ b/test/commands/fragmentation_test.rb
@@ -108,4 +108,28 @@ class FragmentationTest < Test::Unit::TestCase
     Jekyll::Commands::Fragmentation.write_fragment_files(configuration)
     assert_false File.exist?(configuration.fragments_dir)
   end
+
+  def test_many_partitions
+    configuration = config
+    file_name = 'Complex.java'
+    path = "#{configuration.code_root}/org/example/#{file_name}"
+    fragmentation = Jekyll::Commands::Fragmentation.new(path, configuration)
+    fragmentation.write_fragments
+
+    fragment_dir = "#{configuration.fragments_dir}/org/example"
+    fragment_files = Dir.children(fragment_dir)
+    assert_equal 2, fragment_files.size
+
+    fragment_files.delete file_name
+
+    fragment_lines = File.readlines("#{fragment_dir}/#{fragment_files[0]}", chomp: true)
+    assert_equal('public class Main {', fragment_lines[0])
+    assert_equal(configuration.separator, fragment_lines[1])
+    assert_match(/\s{4}public.*/, fragment_lines[2])
+    assert_equal(configuration.separator, fragment_lines[3])
+    assert_match(/\s{8}System.*/, fragment_lines[4])
+    assert_equal('    }', fragment_lines[5])
+    assert_equal(configuration.separator, fragment_lines[6])
+    assert_equal('}', fragment_lines[7])
+  end
 end

--- a/test/resources/code/org/example/Complex.java
+++ b/test/resources/code/org/example/Complex.java
@@ -1,0 +1,20 @@
+// #docfragment "Main"
+public class Main {
+    // #enddocfragment "Main"
+    private Main() {}
+
+    // #docfragment "Main"
+    public static void main(String[] args) {
+        // #enddocfragment "Main"
+        System.out.println("This is just a log message.");
+        // #docfragment "Main"
+        System.out.println(helperMethod());
+    }
+    // #enddocfragment "Main"
+
+    private static String helperMethod() {
+        return "42";
+    }
+// #docfragment "Main"
+}
+// #enddocfragment "Main"

--- a/test/resources/prepared-fragments/plain-text-to-embed.txt
+++ b/test/resources/prepared-fragments/plain-text-to-embed.txt
@@ -1,0 +1,7 @@
+This line contains foo in the middle
+This line ends with foo
+foo — this line starts with it
+
+This line contains bar in the middle
+bar — this line starts with it
+This line ends with bar


### PR DESCRIPTION
This PR contains a couple of behaviour changes, aimed towards simplifying the use of `start`/`end` patterns.

## Fail on invalid patterns

Previously, when an unmatched `end` pattern was submitted, the tool embedded the whole tail of the code file into the document. This is annoying since one might forget to verify the embedding. Now, we fail and give the user an error message regarding their mistake in creating a pattern.

## Allow skipping `*` at the start and in the end

Often the patterns find a "trigger" word, such as a method name, etc. In this case, the pattern had to be surrounded with `*` symbols to signify that the submitted expression only matches a portion of the line. Now, the `*` are implied. If, however, the user wants to match the start or end of the line, they may specify that explicitly using `^` and `$` symbols (in the same way as those symbols are used in regular expressions).

## Fix indents

If a named code fragment had multiple partitions (opened and closed several times), those partitions would not be aligned to the same indent as in the source code. Instead, they would compute their indentation independently. This caused code misalignment in the embeddings. Now, all the indentation is preserved except for the common indent for all the code in all the partitions.

## Also in this PR

 - `README.md` is reworded in some places for better comprehension.
 - `CONTRIBUTING.md` is extracted from `README.md` as a doc targetted only for contributors, not for users.
