### PR TITLE
Fix indexing error

### DIFF
--- a/embed-code.gemspec
+++ b/embed-code.gemspec
@@ -18,7 +18,7 @@
 
 Gem::Specification.new do |s|
   s.name = 'embed-code'
-  s.version = '0.0.2'
+  s.version = '0.0.3'
   s.summary = 'Prepares code samples and embeds them into Markdown files'
   s.authors = ['Spine Event Engine']
   s.files = [

--- a/lib/commands/fragmentation.rb
+++ b/lib/commands/fragmentation.rb
@@ -277,7 +277,11 @@ module Jekyll::Commands
             text += configuration.separator + "\n"
           end
           part_text.each do |line|
-            text += line[common_indentation..-1]
+            if line.strip.empty?
+              text += line
+            else
+              text += line[common_indentation..-1]
+            end
           end
         end
         text.freeze

--- a/test/commands/fragmentation_test.rb
+++ b/test/commands/fragmentation_test.rb
@@ -128,8 +128,9 @@ class FragmentationTest < Test::Unit::TestCase
     assert_match(/\s{4}public.*/, fragment_lines[2])
     assert_equal(configuration.separator, fragment_lines[3])
     assert_match(/\s{8}System.*/, fragment_lines[4])
-    assert_equal('    }', fragment_lines[5])
-    assert_equal(configuration.separator, fragment_lines[6])
-    assert_equal('}', fragment_lines[7])
+    assert_equal('', fragment_lines[5])
+    assert_equal('    }', fragment_lines[6])
+    assert_equal(configuration.separator, fragment_lines[7])
+    assert_equal('}', fragment_lines[8])
   end
 end

--- a/test/resources/code/org/example/Complex.java
+++ b/test/resources/code/org/example/Complex.java
@@ -9,6 +9,7 @@ public class Main {
         System.out.println("This is just a log message.");
         // #docfragment "Main"
         System.out.println(helperMethod());
+
     }
     // #enddocfragment "Main"
 


### PR DESCRIPTION
In this PR we fix a crash caused by a recent change.

The crash occurred when attempting to strip extra indentation off an empty line.

Also, the version is bumped to 0.0.3.