### PR TITLE
Fix crash on multiline instruction

### DIFF
--- a/embed-code.gemspec
+++ b/embed-code.gemspec
@@ -18,7 +18,7 @@
 
 Gem::Specification.new do |s|
   s.name = 'embed-code'
-  s.version = '0.1.0'
+  s.version = '0.1.1'
   s.summary = 'Prepares code samples and embeds them into Markdown files'
   s.authors = ['Spine Event Engine']
   s.files = [

--- a/lib/commands/embedding.rb
+++ b/lib/commands/embedding.rb
@@ -197,7 +197,7 @@ module Jekyll
           end
         end
         unless context.embedding
-          raise StandardError, 'Failed to parse an embedding instruction'
+          raise StandardError, "Failed to parse an embedding instruction. Context: #{context}"
         end
       end
     end

--- a/lib/commands/embedding.rb
+++ b/lib/commands/embedding.rb
@@ -109,7 +109,7 @@ module Jekyll
             end
           end
           unless accepted
-            raise StandardError, "Failed to parse the doc file `#{@doc_file}`."
+            raise StandardError, "Failed to parse the doc file `#{@doc_file}`. Context: #{context}"
           end
         end
         context
@@ -163,6 +163,10 @@ module Jekyll
           return true if @source[i] != @result[i]
         end
         false
+      end
+
+      def to_s
+        "ParsingContext[embedding=`#{@embedding}`, file=`#{@markdown_file}`, line=`#{@line_index}`]"
       end
     end
 

--- a/lib/commands/embedding_instruction.rb
+++ b/lib/commands/embedding_instruction.rb
@@ -82,6 +82,11 @@ module Jekyll::Commands
       end
     end
 
+    def to_s
+      "EmbeddingInstruction[file=`#{@code_file}`, fragment=`#{@fragment}`, " \
+                           "start=`#{@start}`, end=`#{@end}`]"
+    end
+
     private
 
     def matching_lines(lines)

--- a/lib/commands/embedding_instruction.rb
+++ b/lib/commands/embedding_instruction.rb
@@ -57,10 +57,9 @@ module Jekyll::Commands
     # @param [Configuration] configuration tool configuration
     def self.from_xml(line, configuration)
       begin
-        document = Nokogiri::XML(line)
+        document = Nokogiri::XML(line, nil, nil, Nokogiri::XML::ParseOptions::STRICT)
         instruction = document.at_xpath("//#{TAG_NAME}")
-      rescue StandardError => e
-        puts e
+      rescue StandardError
         return nil
       end
       if instruction.nil?

--- a/test/commands/embed_command_test.rb
+++ b/test/commands/embed_command_test.rb
@@ -54,4 +54,13 @@ class EmbedCodeSamplesTest < Test::Unit::TestCase
     updated_content = File.read doc_file
     assert_match(MAIN_METHOD_REGEX, updated_content)
   end
+
+  def test_mind_the_gap
+    doc_file = "#{@config.documentation_root}/blank-line.md"
+
+    Jekyll::Commands::EmbedCodeSamples.process(@config)
+
+    updated_content = File.read doc_file
+    assert_match(MAIN_METHOD_REGEX, updated_content)
+  end
 end

--- a/test/commands/embed_command_test.rb
+++ b/test/commands/embed_command_test.rb
@@ -23,6 +23,8 @@ require_relative './given/test_env'
 
 class EmbedCodeSamplesTest < Test::Unit::TestCase
 
+  MAIN_METHOD_REGEX = /^public static void main.*/
+
   def setup
     @config = config(false, ['**/Hello.java'])
     prepare_docs './test/resources/docs'
@@ -34,15 +36,22 @@ class EmbedCodeSamplesTest < Test::Unit::TestCase
   end
 
   def test_process_files
-    main_method_regex = /^public static void main.*/
-
     doc_file = "#{@config.documentation_root}/doc.md"
     initial_content = File.read doc_file
-    assert_no_match(main_method_regex, initial_content)
+    assert_no_match(MAIN_METHOD_REGEX, initial_content)
 
     Jekyll::Commands::EmbedCodeSamples.process(@config)
 
     updated_content = File.read doc_file
-    assert_match(main_method_regex, updated_content)
+    assert_match(MAIN_METHOD_REGEX, updated_content)
+  end
+
+  def test_allow_splitting_tag
+    doc_file = "#{@config.documentation_root}/split-lines.md"
+
+    Jekyll::Commands::EmbedCodeSamples.process(@config)
+
+    updated_content = File.read doc_file
+    assert_match(MAIN_METHOD_REGEX, updated_content)
   end
 end

--- a/test/resources/docs/blank-line.md
+++ b/test/resources/docs/blank-line.md
@@ -1,0 +1,6 @@
+# Test number five
+
+<embed-code file="org/example/Hello.java" fragment="main()"></embed-code>
+    
+```java
+```

--- a/test/resources/docs/blank-line.md
+++ b/test/resources/docs/blank-line.md
@@ -2,5 +2,6 @@
 
 <embed-code file="org/example/Hello.java" fragment="main()"></embed-code>
     
+
 ```java
 ```

--- a/test/resources/docs/split-lines.md
+++ b/test/resources/docs/split-lines.md
@@ -1,0 +1,6 @@
+# Test number four
+
+<embed-code file="org/example/Hello.java"
+            fragment="main()"></embed-code>
+```java
+```

--- a/test/resources/docs/split-lines.md
+++ b/test/resources/docs/split-lines.md
@@ -1,6 +1,7 @@
 # Test number four
 
 <embed-code file="org/example/Hello.java"
-            fragment="main()"></embed-code>
+            fragment="main()">
+</embed-code>
 ```java
 ```


### PR DESCRIPTION
The tool used to crash when splitting an embedding instruction into several lines:
```
<embed-code file="..."
            start="..."
            end="...">
```
This was caused by an obscure behaviour of the parsing tool, which tried to patch up XML errors instead of reporting them, which led our state machine into an illegal state.

Now this crash is fixed. 

Also in this PR we allow users to add blank lines between the embedding instruction and the code fence. For example:
```
<embed-code ...>


` ` ` java
` ` `
```

The only reason to do so is for clearer formatting.